### PR TITLE
Update lesson-25-intro-to-core-async.md

### DIFF
--- a/content/section-4/lesson-25-intro-to-core-async.md
+++ b/content/section-4/lesson-25-intro-to-core-async.md
@@ -168,7 +168,7 @@ One common use case is to implement a timeout by alternating between a channel t
 
 ```clojure
 (go
-  (let [[val ch] (alts! long-task-ch (timeout 5000))]
+  (let [[val ch] (alts! [long-task-ch (timeout 5000)])]
     (if (= ch long-task-ch)
       (println "Task completed!" val)
       (println "Oh oh! Task timed out!"))))


### PR DESCRIPTION
`alts!` takes a vector of channels as its first argument. The time we use `alts!` in the Detecting Key Chords example the syntax is right. This time we specify the channels as separate arguments. Which means the second channel is interpreted as an option to `alts!` and we get a very puzzling error message.