### PR TITLE
fix(section-2): update typos and grammar

### DIFF
--- a/content/section-2/lesson-10-making-choices.md
+++ b/content/section-2/lesson-10-making-choices.md
@@ -356,7 +356,7 @@ Compared to our original implementation with nested if statements, this version 
 
 ### Quick Review
 
-- Using `cond` to write some code that will evaluate to `:pos` when a given number is positive, `:neg` when it is negative, and `:zero` when it is exactly zero
+- Use `cond` to write some code that will evaluate to `:pos` when a given number is positive, `:neg` when it is negative, and `:zero` when it is exactly zero
 - Write code that will do the same thing using `condp`
 
 ## Summary

--- a/content/section-2/lesson-10-making-choices.md
+++ b/content/section-2/lesson-10-making-choices.md
@@ -141,7 +141,7 @@ For the second case, we will often want to perform some DOM manipulation or othe
 
 ### Applying if and when
 
-Considering the example of the adventure game, we can use use an `if` expression to determine what to do after prompting the user for a yes/no question. Let's take a quick step back to discuss the overall architecture of the game. We will represent the entire game as a map where the keys are the name of each state and the values are maps that represent a specific screen. The general shape of our game data structure is below:
+Considering the example of the adventure game, we can use an `if` expression to determine what to do after prompting the user for a yes/no question. Let's take a quick step back to discuss the overall architecture of the game. We will represent the entire game as a map where the keys are the name of each state and the values are maps that represent a specific screen. The general shape of our game data structure is below:
 
 We will represent our game as a collection of states with rules that determine how to move between states when the user makes some decision:
 

--- a/content/section-2/lesson-10-making-choices.md
+++ b/content/section-2/lesson-10-making-choices.md
@@ -297,7 +297,7 @@ values for "TEST":
 
 ## More Complex Choices With cond
 
-With `if` and `when`, we have all that we technically need to handle any sort of decision-making that we need to do in code. However, we are often faced with cases in which `if` would be awkward to use. Consider adding more commands to our game so that the user could type "restart" to go back to the beginning or "help" to display the commands that are available. As we add more options, we would have to keep nesting more and more`if` expressions - like using a pocket knife to carve a wooden sculpture, it could work, but the result would not be pleasant.
+With `if` and `when`, we have all that we technically need to handle any sort of decision-making that we need to do in code. However, we are often faced with cases in which `if` would be awkward to use. Consider adding more commands to our game so that the user could type "restart" to go back to the beginning or "help" to display the commands that are available. As we add more options, we would have to keep nesting more and more `if` expressions - like using a pocket knife to carve a wooden sculpture, it could work, but the result would not be pleasant.
 
 Enter `cond` and its cousins, `condp` and `case`. `cond` takes some expression and any number of test/result pairs, and the entire expression will evaluate to the "then" expression that comes after the first test that is truthy:
 

--- a/content/section-2/lesson-11-looping.md
+++ b/content/section-2/lesson-11-looping.md
@@ -70,7 +70,7 @@ _Finding the Square of 0-9_
 1. Yield a new sequence by taking the numbers 0-9
 2. Make each number in the new sequence the square of the original
 
-By now we should see that when used with a single input sequence, `for` describes a whole-sequence transformation. When working with ClojureScript, we should try to think whether the problem before us could be represented as a sequence transformation. If so, `for` provides a no-nonsense solution. Let's look at the same problem solved iteratively and with `for`. Imagine that we have a number of right triangles. We know the sides that are adjacent to the right angle, and we need to find the hypotenuse of each triangle. Fist, an iterative solution in JavaScript:
+By now we should see that when used with a single input sequence, `for` describes a whole-sequence transformation. When working with ClojureScript, we should try to think whether the problem before us could be represented as a sequence transformation. If so, `for` provides a no-nonsense solution. Let's look at the same problem solved iteratively and with `for`. Imagine that we have a number of right triangles. We know the sides that are adjacent to the right angle, and we need to find the hypotenuse of each triangle. First, an iterative solution in JavaScript:
 
 <!-- TODO: diagram -->
 

--- a/content/section-2/lesson-11-looping.md
+++ b/content/section-2/lesson-11-looping.md
@@ -6,7 +6,7 @@ date: 2019-09-19T20:50:20-06:00
 
 # Lesson 11: Looping
 
-In the last lesson, we looked at ClojureScript's versions of we usually call branching control structure. However, we learned that things work a little bit different in ClojureScript compared to other languages that we may be used to - control structures are expressions rather than imperative controls. Now as we come to another fundamental topic - loops - we will learn that things are once again a bit different in ClojureScript.
+In the last lesson, we looked at ClojureScript's versions of what we usually call branching control structure. However, we learned that things work a little bit different in ClojureScript compared to other languages that we may be used to - control structures are expressions rather than imperative controls. Now as we come to another fundamental topic - loops - we will learn that things are once again a bit different in ClojureScript.
 
 ---
 

--- a/content/section-2/lesson-12-reusing-code-with-functions.md
+++ b/content/section-2/lesson-12-reusing-code-with-functions.md
@@ -6,7 +6,7 @@ date: 2019-09-22T07:00:50-06:00
 
 # Lesson 12: Reusing Code With Functions
 
-ClojureScript is a functional programming language. The functional programming paradigm gives us superpowers, but - love it or hate it - it also makes certain demands on the way that we write code. We have already discussed some of the implications of functional code (immutable data, minimizing side effects, etc.), but up to this point we have not studied what a functions _are_ - much less how to use them idiomatically. In this lesson, we define what functions are in ClojureScript, and we will study how to define and use them. Finally, we'll look at some best practices for when to break code into separate functions and how to use a special class of function that is encountered often in ClojureScript - the recursive function.
+ClojureScript is a functional programming language. The functional programming paradigm gives us superpowers, but - love it or hate it - it also makes certain demands on the way that we write code. We have already discussed some of the implications of functional code (immutable data, minimizing side effects, etc.), but up to this point we have not studied what functions _are_ - much less how to use them idiomatically. In this lesson, we define what functions are in ClojureScript, and we will study how to define and use them. Finally, we'll look at some best practices for when to break code into separate functions and how to use a special class of function that is encountered often in ClojureScript - the recursive function.
 
 ---
 

--- a/content/section-2/lesson-12-reusing-code-with-functions.md
+++ b/content/section-2/lesson-12-reusing-code-with-functions.md
@@ -166,20 +166,20 @@ First, a function can be declared with multiple _arities_ - that is, its behavio
 ```clojure
 (defn my-multi-arity-fn
  ([a] (println "Called with 1 argument" a))                ;; <1>
- (                                                         ;; <2>
-  [a b]                                                    ;; <3>
-  (println "Called with 2 arguments" a b)                  ;; <4>
+ (
+  [a b]                                                    ;; <2>
+  (println "Called with 2 arguments" a b)                  ;; <3>
  )
  ([a b c] (println "Called with 3 arguments" a b c)))
 
-(defn my-single-arity-fn [a]                               ;; <5>
+(defn my-single-arity-fn [a]                               ;; <4>
   (println "I can only be called with 1 argument"))
 ```
 
 1. Unlike the basic `defn` form, each function implementation is enclosed in a list
 2. For each function implementation, the first element in the list is the parameter vector
 3. ...followed by one or more expressions, forming the body of the implementation for that arity
-5. Remember that for a single-arity function, the parameters and expressions that form the body of the function need not be enclosed in a list
+4. Remember that for a single-arity function, the parameters and expressions that form the body of the function need not be enclosed in a list
 
 Multiple arity functions are often used to supply default parameters. Consider the following function that can add an item to a shopping cart. The 3-ary version lets a quantity be specified along with the `product-id`, and the 2-ary version calls this 3-ary version with a default quantity of `1`:
 

--- a/content/section-2/lesson-12-reusing-code-with-functions.md
+++ b/content/section-2/lesson-12-reusing-code-with-functions.md
@@ -262,7 +262,7 @@ Now that we have learned how to define functions mechanically, let's take a step
 
 In Lesson 4, we took it for granted that an s-expression like `(+ 5 3)` evaluates to `8`, but we did not consider how this happened. We need to expand that mental model of evaluation to account for what happens when a function is called.
 
-When we define a function, we declare a list of parameters. These are called the `formal parameters` of the function. The function body is free to refer to any of these formal parameters. When the function is called, the call is replaces with the body of the function where every instance of the formal parameters is replaced with the argument that was passed in - called the `actual parameters`. While this is a bit confusing to explain, a quick example should help clarify:
+When we define a function, we declare a list of parameters. These are called the `formal parameters` of the function. The function body is free to refer to any of these formal parameters. When the function is called, the call is replaced with the body of the function where every instance of the formal parameters is replaced with the argument that was passed in - called the `actual parameters`. While this is a bit confusing to explain, a quick example should help clarify:
 
 ```clojure
 (defn hypotenuse [a b]                                     ;; <1>

--- a/content/section-2/lesson-12-reusing-code-with-functions.md
+++ b/content/section-2/lesson-12-reusing-code-with-functions.md
@@ -363,7 +363,7 @@ The real power comes when we move from specific, granular function to higher lev
 ### Quick Review
 
 - Define a function using `my-inc` that returns the increment of a number. How would you define a function with the same name without using `defn`?
-- What is the difference between the _formal parameters_ and _actual parameters_
+- What is the difference between the _formal parameters_ and _actual parameters_?
 - What does _shadowing_ mean in the context of a closure?
 
 ## Recursion 101

--- a/content/section-2/lesson-12-reusing-code-with-functions.md
+++ b/content/section-2/lesson-12-reusing-code-with-functions.md
@@ -260,7 +260,7 @@ Now that we have learned how to define functions mechanically, let's take a step
 ;; => 16
 ```
 
-In Lesson 4, we took it for granted that an s-expression like `(+ 5 3)` evaluates to `8`, but we did not consider how this happened. We need to expand that mental model of evaluation to account for what happens a function is called.
+In Lesson 4, we took it for granted that an s-expression like `(+ 5 3)` evaluates to `8`, but we did not consider how this happened. We need to expand that mental model of evaluation to account for what happens when a function is called.
 
 When we define a function, we declare a list of parameters. These are called the `formal parameters` of the function. The function body is free to refer to any of these formal parameters. When the function is called, the call is replaces with the body of the function where every instance of the formal parameters is replaced with the argument that was passed in - called the `actual parameters`. While this is a bit confusing to explain, a quick example should help clarify:
 

--- a/content/section-2/lesson-13-interacting-with-javascript-data.md
+++ b/content/section-2/lesson-13-interacting-with-javascript-data.md
@@ -291,7 +291,7 @@ var books = [
 ];
 ```
 
-- Write an expression that will retrieve the value, "Scheme":
+- Write an expression that will retrieve the value, "Scheme".
 - Write an expression that will have the side effect of changing the title "All About Animals" to "Dangerous Creatures".
 
 ### Challenge

--- a/content/section-2/lesson-13-interacting-with-javascript-data.md
+++ b/content/section-2/lesson-13-interacting-with-javascript-data.md
@@ -244,7 +244,7 @@ _Getting and Setting Array Elements_
 
 1. Bind a var to a JavaScript array
 2. Get the element at index `2`
-3. Get the element at index `5` to `13`
+3. Set the element at index `5` to `13`
 4. `aset` has mutated the array
 
 We can also access the JavaScript array methods by using, `(.functionName array args*)`. This is the standard syntax for calling a method on a JavaScript object, which we will explain in much more detail later.

--- a/content/section-2/lesson-13-interacting-with-javascript-data.md
+++ b/content/section-2/lesson-13-interacting-with-javascript-data.md
@@ -47,7 +47,7 @@ This creates a global JavaScript variable called `testScores`, which we can acce
 
 _Sharing Data Between Browser and REPL_
 
-We can use the REPL to inspect this variable, convert it to a ClojureScript data structure, modify it and write a new version back out the the `testScores` variable.
+We can use the REPL to inspect this variable, convert it to a ClojureScript data structure, modify it and write a new version back out the `testScores` variable.
 
 ```clojure
 cljs.user=> (def cljs-scores (js->clj js/testScores))      ;; <1>

--- a/content/section-2/lesson-14-performing-io.md
+++ b/content/section-2/lesson-14-performing-io.md
@@ -192,7 +192,7 @@ Here, we use the `goog.dom.getElement()` function to retrieve the input element 
 
 In this expression, we get the `value` property of the input element, which will contain whatever text the user has typed into it, and update the text content of the target node with this value. This code performs both the input (reading the input's `value`) and output (writing the text content of the `target`).
 
-Since we will not spend much time with low-level DOM manipulation, we will not linger on this subject. If we ever find ourselves having to do write DOM manipulation code, the Google Closure library has excellent documentation. Otherwise, do not be afraid to find a good ClojureScript DOM library and use it!
+Since we will not spend much time with low-level DOM manipulation, we will not linger on this subject. If we ever find ourselves having to write DOM manipulation code, the Google Closure library has excellent documentation. Otherwise, do not be afraid to find a good ClojureScript DOM library and use it!
 
 ### You Try It
 

--- a/content/section-2/lesson-15-capstone-temperature-converter.md
+++ b/content/section-2/lesson-15-capstone-temperature-converter.md
@@ -204,7 +204,7 @@ _src/learn_cljs/temp_converter.cljs_
 3. Store each element that we will use in a var
 4. Helper functions
 5. Event handling callback
-6. Attach event handler to `keyup` event in the temperature input and the click event on each radio button
+6. Attach event handler to `keyup` event in the temperature input and the `click` event on each radio button
 
 ### Challenge
 


### PR DESCRIPTION
lesson-10 remove duplicate word, add space, and change using to use

lesson-11 add missing what and fix typo Fist to First

lesson-12 remove article a, realign code notation, change replaces to replaced, add missing question mark

lesson-13 remove duplicate the, change Get to Set, change colon to semicolon to be consistent with the other sentence

lesson-14 remove excess do

lesson-15 add code markup to click to be consistent with keyup