### PR TITLE
Update lesson-20-capstone-3-contact-book.md

### DIFF
--- a/content/section-3/lesson-20-capstone-3-contact-book.md
+++ b/content/section-3/lesson-20-capstone-3-contact-book.md
@@ -124,7 +124,7 @@ With this macro, we can make our `make-contact` function even clearer:
 
 (defn make-contact [contact]
   (-> contact                                              ;; <2>
-      (select-keys [:first-name :last-name :email])
+      (select-keys [:first-name :last-name :email :address])
       (maybe-set-address)))
 ```
 


### PR DESCRIPTION
Fix issue [#81](https://github.com/kendru/learn-cljs/issues/81): 
`make-contact` function returns contact without `:address` field now. This fix force it to return contact with `:address` field.