### PR TITLE
Fix updating output logic

### DIFF
--- a/content/section-4/lesson-21-functional-programming-concepts.md
+++ b/content/section-4/lesson-21-functional-programming-concepts.md
@@ -171,17 +171,17 @@ While we need side effects, we should strive to segregate functions that perform
 While this code gets the job done, it is not especially clean or elegant because it both performs a conversion and does I/O. In order to test this code, we need to run it on a page where all of the elements exist, and in order to test it, we would have to manually set the input fields, call the function, then assert on the content of the output element. Instead, we could refactor this into several pure functions: a pure function to get the label, a pure function to perform the conversion, and an impure function that reads from and mutates the DOM.
 
 ```clojure
-(defn target-label-for-output-unit [unit]          ;; 1
+(defn target-label-for-output-unit [unit]          ;; <1>
   (case unit
     :fahrenheit "C"
     :celsius "F"))
 
-(defn convert [unit temp]                          ;; 2
+(defn convert [unit temp]                          ;; <2>
   (if (= unit :celsius)
     (c->f temp)
     (f->c temp)))
 
-(defn update-output [_]                            ;; 3
+(defn update-output [_]                            ;; <3>
   (let [unit (get-input-unit)
         input-temp (get-input-temp)
         output-temp (convert unit input-temp)

--- a/content/section-4/lesson-21-functional-programming-concepts.md
+++ b/content/section-4/lesson-21-functional-programming-concepts.md
@@ -171,21 +171,21 @@ While we need side effects, we should strive to segregate functions that perform
 While this code gets the job done, it is not especially clean or elegant because it both performs a conversion and does I/O. In order to test this code, we need to run it on a page where all of the elements exist, and in order to test it, we would have to manually set the input fields, call the function, then assert on the content of the output element. Instead, we could refactor this into several pure functions: a pure function to get the label, a pure function to perform the conversion, and an impure function that reads from and mutates the DOM.
 
 ```clojure
-(defn target-label-for-input-unit [unit]                   ;; <1>
+(defn target-label-for-output-unit [unit]          ;; 1
   (case unit
-    :fahrenheit "F"
-    :celsius "C"))
+    :fahrenheit "C"
+    :celsius "F"))
 
-(defn convert [unit temp]                                  ;; <2>
-  (if (= :celsius unit)
+(defn convert [unit temp]        ;; 2
+  (if (= unit :celsius)
     (c->f temp)
     (f->c temp)))
 
-(defn update-output [_]                                    ;; <3>
+(defn update-output [_]        ;; 3
   (let [unit (get-input-unit)
         input-temp (get-input-temp)
         output-temp (convert unit input-temp)
-        output-label (target-label-for-input-unit unit)]
+        output-label (target-label-for-output-unit unit)]
     (set-output-temp output-temp)
     (gdom/setTextContent output-unit-target output-label)))
 ```

--- a/content/section-4/lesson-21-functional-programming-concepts.md
+++ b/content/section-4/lesson-21-functional-programming-concepts.md
@@ -176,12 +176,12 @@ While this code gets the job done, it is not especially clean or elegant because
     :fahrenheit "C"
     :celsius "F"))
 
-(defn convert [unit temp]        ;; 2
+(defn convert [unit temp]                          ;; 2
   (if (= unit :celsius)
     (c->f temp)
     (f->c temp)))
 
-(defn update-output [_]        ;; 3
+(defn update-output [_]                            ;; 3
   (let [unit (get-input-unit)
         input-temp (get-input-temp)
         output-temp (convert unit input-temp)


### PR DESCRIPTION
This PR fixes issue #83 
Current code leads to the same labels for input and output. 

![Screenshot from 2022-11-12 18-24-08](https://user-images.githubusercontent.com/46072351/201484908-38032d4d-29a3-46dc-970e-892873832bdb.png)


New code fixes this issue. 

![Screenshot from 2022-11-12 18-25-41](https://user-images.githubusercontent.com/46072351/201484854-eef5e263-b55d-48db-9d40-303d043c6c91.png)

New function name `target-label-for-output-unit` says that we are defining label for output, not input.