### PR TITLE
[Lesson 10] Fix :on-continue bug in starbase.cljs

### DIFF
--- a/code/lesson-10/starbase/src/learn_cljs/starbase.cljs
+++ b/code/lesson-10/starbase/src/learn_cljs/starbase.cljs
@@ -26,7 +26,7 @@
 (defn on-answer [game current answer]
   (let [scene (get game current)]
     (if (= :skip (:type scene))
-      (:on-continue scene)
+      (prompt game (:on-continue scene))
       (condp = answer
         "reset" (prompt game :start)
         "help" (do (io/clear term)


### PR DESCRIPTION
The game would hang up when reaching the `:off-the-planet` scene. Now it continues to the `:into-the-nebula` scene as it should.