### PR TITLE
fix nested JS objects in lesson 13

### DIFF
--- a/content/section-2/lesson-13-interacting-with-javascript-data.md
+++ b/content/section-2/lesson-13-interacting-with-javascript-data.md
@@ -205,9 +205,9 @@ Since property access supports nested properties, it only makes sense that the t
 
 ```clojure
 (def student #js {"locker" 212
-                  "grades" {"Math" "A",
-                            "Physics" "B",
-                            "English" "A+"}})
+                  "grades" #js {"Math" "A",
+                                "Physics" "B",
+                                "English" "A+"}})
 ```
 
 Unlike the functions that we have seen that operate on ClojureScript data, `set!` actually modifies the object in-place. This is because we are working with mutable JavaScript data.


### PR DESCRIPTION
Before this change I don't think the solution to this experiment works as intended. I have this:

```
(set! (.-grades student) (assoc (.-grades student) "Physics" "C"))
```

But afaict the lessons haven't gone over `assoc` yet, so I get the sense this isn't the intended answer.

After this change the answer is

```
(set! (.. student -grades -Physics) "C")
```

which feels more appropriate for what the lesson discusses up to this point.